### PR TITLE
Add aggregate_expression FactModel feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,22 @@ class TicketFactModel < ActiveReporting::FactModel
 end
 ```
 
+## Configuring Aggregate Expressions for `COUNT`
+
+If you need more granular control over the `COUNT` aggregate function, you can declare an [aggregate expression](https://www.postgresql.org/docs/8.2/static/functions-aggregate.html) in the fact model. This use case can arise if need multiple aggregates on identical data sets.
+
+The declaration takes the raw SQL expression that
+you want to replace `'*'` in the `COUNT` function:
+
+```ruby
+class TicketFactModel < ActiveReporting::FactModel
+  aggregate_expression :my_custom_expression,
+                       "CASE WHEN name = 'foo' THEN 1 END"
+end
+```
+
+Whatever expression you choose, it is important to remember that `COUNT` will aggregate all non-`null` results -- so anything you want to exclude should compute to `null`.
+
 ## ActiveReporting::Metric
 
 A `Metric` is the basic building block used to describe a question you want to answer. At minimum, a metric needs a name, a fact table and an aggregate. You can expand a metric further by including dimensions and dimension filters.
@@ -261,7 +277,7 @@ my_metric = ActiveReporting::Metric.new(
 
 `fact_model` - An `ActiveReporting::FactModel` class
 
-`aggregate` - The SQL aggregate used to calculate the metric. Supported aggregates include count, max, min, avg, and sum. (Default: `:count`)
+`aggregate` - The SQL aggregate used to calculate the metric. Supported aggregates include count, max, min, avg, and sum. (Default: `:count`.) For `count` aggregates, you can also specify an aggregate expression if you defined one in your fact model: `aggregate: { count: :my_custom_expression }` -- and the expression identified will replace the `'*'` when a query is made using `COUNT`.
 
 `dimensions` - An array of dimensions used for the metric. When given just a symbol, the default dimension label will be used for the dimension. You may specify a hierarchy level by using a hash. (Examples: `[:sales_rep, {order_date: :month}]`)
 
@@ -339,4 +355,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/active_reporting/fact_model.rb
+++ b/lib/active_reporting/fact_model.rb
@@ -94,6 +94,33 @@ module ActiveReporting
       @dimensions[name.to_sym] = Dimension.new(self, name: name)
     end
 
+    # Declares an aggregate expression that can be used in a Metric. See, e.g.:
+    # https://www.postgresql.org/docs/8.2/static/functions-aggregate.html
+    #
+    # @note
+    #   Currently support provided for `COUNT` function only.
+    #
+    # @param name [String, Symbol]
+    # @param expression [String] SQL expression
+    #
+    # @example
+    #   class FooFactModel < ActiveReporting::FactModel
+    #     aggregate_expression :bar_is_5, "CASE WHEN bar = '5' THEN 1 END"
+    #   end
+    #
+    #   m = ActiveReporting::Metric.new(:bar_count,
+    #                                   fact_model: FooFactModel,
+    #                                   aggregate: { count: :bar_is_5 } )
+    #
+    def self.aggregate_expression(name, expression)
+      @aggregate_expressions ||= {}
+      @aggregate_expressions[name.to_sym] = expression
+    end
+
+    def self.aggregate_expressions
+      @aggregate_expressions || {}
+    end
+
     # Returns a hash of dimension label to callback mappings
     #
     # @return [Hash]

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -76,7 +76,7 @@ module ActiveReporting
     def select_aggregate
       case @metric.aggregate
       when :count
-        'COUNT(*)'
+        "COUNT(#{@metric.aggregate_expression})"
       else
         "#{@metric.aggregate.to_s.upcase}(#{fact_model.measure})"
       end

--- a/test/active_reporting/metric_test.rb
+++ b/test/active_reporting/metric_test.rb
@@ -45,4 +45,20 @@ class ActiveReporting::MetricTest < Minitest::Test
     assert metric.order_by_dimension.is_a?(Hash)
     assert_equal({:kind => :asc}, metric.order_by_dimension)
   end
+
+  def test_metric_raises_when_using_expression_for_unsupported_aggregate
+    assert_raises ActiveReporting::UnknownAggregate do
+      ActiveReporting::Metric.new(
+        :a, fact_model: FigureFactModel, dimensions: [:kind], aggregate: { sum: :kind_is_card }
+      )
+    end
+  end
+
+  def test_metric_raises_when_using_undefined_expression
+    assert_raises ActiveReporting::UnknownAggregate do
+      ActiveReporting::Metric.new(
+        :a, fact_model: FigureFactModel, dimensions: [:kind], aggregate: { sum: :foo }
+      )
+    end
+  end
 end

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -31,4 +31,31 @@ class ActiveReporting::ReportTest < Minitest::Test
     refute data.empty?
     assert data.all? { |r| r.key?('a_metric') }
   end
+
+  def test_report_runs_aggregate_with_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { count: :kind_is_card }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
+      assert d['a_metric'].zero?
+    end
+    refute(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'].zero?)
+  end
+
+  def test_report_count_is_zero_with_aggregate_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { count: :kind_is_foo }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    assert data.all? { |r| r['a_metric'].zero? }
+  end
 end

--- a/test/fact_models.rb
+++ b/test/fact_models.rb
@@ -2,6 +2,9 @@ class FigureFactModel < ActiveReporting::FactModel
   dimension :kind
   dimension :series
 
+  aggregate_expression :kind_is_card, "CASE WHEN kind = 'amiibo card' THEN 1 END"
+  aggregate_expression :kind_is_foo, "CASE WHEN kind = 'foo' THEN 1 END"
+
   dimension_filter :kind_is, ->(k) { where(kind: k) }
 end
 


### PR DESCRIPTION
Adds the ability to specifiy an aggregate expression for COUNT
aggregates. This is useful to when running mutliple aggregates on
identically dimensioned data. The expression must be defined in the
fact model, and then invoked when creating an ActiveReports::Metric.