### PR TITLE
Extend aggregate expression feature

### DIFF
--- a/lib/active_reporting.rb
+++ b/lib/active_reporting.rb
@@ -32,11 +32,12 @@ module ActiveReporting
     klass.constantize.lookup(name)
   end
 
-  BadMetricLookupClass    = Class.new(StandardError)
-  InvalidDimensionLabel   = Class.new(StandardError)
-  RansackNotAvailable     = Class.new(StandardError)
-  UnknownAggregate        = Class.new(StandardError)
-  UnknownDimension        = Class.new(StandardError)
-  UnknownDimensionFilter  = Class.new(StandardError)
-  UnknownMetric           = Class.new(StandardError)
+  BadMetricLookupClass       = Class.new(StandardError)
+  InvalidDimensionLabel      = Class.new(StandardError)
+  RansackNotAvailable        = Class.new(StandardError)
+  UnknownAggregate           = Class.new(StandardError)
+  UnknownAggregateExpression = Class.new(StandardError)
+  UnknownDimension           = Class.new(StandardError)
+  UnknownDimensionFilter     = Class.new(StandardError)
+  UnknownMetric              = Class.new(StandardError)
 end

--- a/lib/active_reporting/metric.rb
+++ b/lib/active_reporting/metric.rb
@@ -10,6 +10,7 @@ module ActiveReporting
                 :dimensions,
                 :dimension_filter,
                 :aggregate,
+                :aggregate_expression,
                 :metric_filter,
                 :order_by_dimension
 
@@ -39,12 +40,6 @@ module ActiveReporting
       Report.new(self)
     end
 
-    # Return the specified aggregate expression, defaulting to '*'
-    #
-    def aggregate_expression
-      @aggregate_expression || '*'
-    end
-
     private ####################################################################
 
     def check_dimension_filter
@@ -56,18 +51,15 @@ module ActiveReporting
     def validate_aggregate(agg)
       agg_name, expr = agg.is_a?(Hash) ? Array(agg).flatten : [agg.to_sym, nil]
       raise UnknownAggregate, "Unknown aggregate '#{agg_name}'" unless AGGREGATES.include?(agg_name)
-      validate_agg_expression(agg_name, expr) if expr
+      validate_agg_expression(expr) if expr
       @aggregate = agg_name
       @aggregate_expression = @fact_model.aggregate_expressions[expr]
     end
 
-    def validate_agg_expression(agg_name, expr)
-      if agg_name != :count
-        raise UnknownAggregate, "Currently no aggregate expression support for '#{agg_name}'"
-      elsif @fact_model.aggregate_expressions[expr].nil?
-        raise UnknownAggregate,
-              "Aggregate expression '#{expr}' not defined in '#{@fact_model.name}'"
-      end
+    def validate_agg_expression(expr)
+      return if @fact_model.aggregate_expressions[expr]
+      raise UnknownAggregateExpression,
+            "Aggregate expression '#{expr}' not defined in '#{@fact_model.name}'"
     end
   end
 end

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -76,9 +76,9 @@ module ActiveReporting
     def select_aggregate
       case @metric.aggregate
       when :count
-        "COUNT(#{@metric.aggregate_expression})"
+        "COUNT(#{@metric.aggregate_expression || '*'})"
       else
-        "#{@metric.aggregate.to_s.upcase}(#{fact_model.measure})"
+        "#{@metric.aggregate.to_s.upcase}(#{@metric.aggregate_expression || fact_model.measure})"
       end
     end
 

--- a/test/active_reporting/metric_test.rb
+++ b/test/active_reporting/metric_test.rb
@@ -46,16 +46,8 @@ class ActiveReporting::MetricTest < Minitest::Test
     assert_equal({:kind => :asc}, metric.order_by_dimension)
   end
 
-  def test_metric_raises_when_using_expression_for_unsupported_aggregate
-    assert_raises ActiveReporting::UnknownAggregate do
-      ActiveReporting::Metric.new(
-        :a, fact_model: FigureFactModel, dimensions: [:kind], aggregate: { sum: :kind_is_card }
-      )
-    end
-  end
-
   def test_metric_raises_when_using_undefined_expression
-    assert_raises ActiveReporting::UnknownAggregate do
+    assert_raises ActiveReporting::UnknownAggregateExpression do
       ActiveReporting::Metric.new(
         :a, fact_model: FigureFactModel, dimensions: [:kind], aggregate: { sum: :foo }
       )

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -44,7 +44,7 @@ class ActiveReporting::ReportTest < Minitest::Test
     data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
       assert d['a_metric'].zero?
     end
-    refute(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'].zero?)
+    assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552)
   end
 
   def test_report_count_is_zero_with_aggregate_expression
@@ -72,5 +72,20 @@ class ActiveReporting::ReportTest < Minitest::Test
         report = ActiveReporting::Report.new(metric)
       end
     end
+  end
+
+  def test_report_sum_is_520_x_20_with_aggregate_expression
+    metric = ActiveReporting::Metric.new(
+      :a_metric,
+      fact_model: FigureFactModel,
+      dimensions: [:kind],
+      aggregate: { sum: :return_20_when_card }
+    )
+    report = ActiveReporting::Report.new(metric)
+    data = report.run
+    data.reject { |d| d['kind'] == 'amiibo card' }.each do |d|
+      assert d['a_metric'].zero?
+    end
+    assert(data.find { |d| d['kind'] == 'amiibo card' }['a_metric'] == 552 * 20)
   end
 end

--- a/test/fact_models.rb
+++ b/test/fact_models.rb
@@ -4,6 +4,7 @@ class FigureFactModel < ActiveReporting::FactModel
 
   aggregate_expression :kind_is_card, "CASE WHEN kind = 'amiibo card' THEN 1 END"
   aggregate_expression :kind_is_foo, "CASE WHEN kind = 'foo' THEN 1 END"
+  aggregate_expression :return_20_when_card, "CASE WHEN kind = 'amiibo card' THEN 20 ELSE 0 END"
 
   dimension_filter :kind_is, ->(k) { where(kind: k) }
 end


### PR DESCRIPTION
Allows aggregate expressions to be applied to any of the aggregate
functions, instead of solely the 'count' function. Also adds an
error class dedidated to a missing aggregate expression in a fact
model.