### PR TITLE
Provide MySQL support for implicit datetime hierarchies

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,12 @@ class PhoneFactModel < ActiveReporting::FactModel
 end
 ```
 
-### Implicit hierarchies with datetime columns (PostgreSQL support only)
+### Implicit hierarchies with datetime columns
 
 The fastest approach to group by certain date metrics is to create so-called "date dimensions". For
-those Postgres users that are restricted from organizing their data in this way, Postgres provides
-a way to group by `datetime` column data on the fly using the `date_trunc` function.
+those users that are restricted from organizing their data in this way, There is a mechanism
+to group by `datetime` column data on the fly -- on Postgres, this is done using the `date_trunc` function;
+on MySQL, this is done using some messy code utilizing the `INTERVAL` function.
 
 To use, declare a datetime dimension on a fact model as normal:
 
@@ -233,9 +234,7 @@ class UserFactModel < ActiveReporting::FactModel
 end
 ```
 
-When creating a metric, ActiveReporting will recognize implicit hierarchies for this dimension. The hierarchies correspond to the [values](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC) supported by PostgreSQL. (See example under the metric section, below.)
-
-*NOTE*: PRs welcomed to support this functionality in other databases.
+When creating a metric, ActiveReporting will recognize implicit hierarchies for this dimension. The hierarchies correspond to the [values](https://www.postgresql.org/docs/8.1/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC) supported by PostgreSQL and have been ported over for identical use under MySQL. (See example under the metric section, below.)
 
 ## Configuring Dimension Filters
 
@@ -293,7 +292,7 @@ my_metric = ActiveReporting::Metric.new(
 
 `order_by_dimension` - Allows you to set the ordering of the results based on a dimension label. (Examples: `{author: :desc}`, `{sales_ref: :asc}`)
 
-For those using Postgres, you can take advantage of implicit hierarchies in `datetime` columns, as mentioned above:
+You can also take advantage of implicit hierarchies in `datetime` columns, as mentioned above:
 
 ```ruby
 class UserFactModel < ActiveReporting::FactModel

--- a/lib/active_reporting/function_adapters/mappings.rb
+++ b/lib/active_reporting/function_adapters/mappings.rb
@@ -1,0 +1,12 @@
+require 'active_reporting/function_adapters/postgresql'
+require 'active_reporting/function_adapters/mysql'
+
+module ActiveReporting
+  module FunctionAdapters
+    MAPPINGS = {
+      'PostgreSQL' => Postgresql,
+      'PostGIS' => Postgresql,
+      'Mysql2' => Mysql
+    }.freeze
+  end
+end

--- a/lib/active_reporting/function_adapters/mysql.rb
+++ b/lib/active_reporting/function_adapters/mysql.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module ActiveReporting
+  module FunctionAdapters
+    module Mysql
+      # The list of available datetime values.
+      #
+      # @return [Array<Symbol>]
+      #
+      def self.datetime_precision_values
+        %i[microsecond millisecond second minute hour day week month quarter year decade
+           century millennium].freeze
+      end
+
+      # Whether the arg value is supported as a viable datetime
+      # value for performing datetime functions.
+      #
+      def self.valid_datetime_precision_value?(value)
+        datetime_precision_values.include?(value)
+      end
+
+      # Generate a date truncation statement in MySQL
+      # See https://www.postgresql.org/docs/10/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+      #
+      # @param [String, Symbol] datetime_precision_value
+      # @param [String] quoted_table_name
+      # @param [String] column_name
+      #
+      def self.date_truncate(datetime_precision_value, quoted_table_name, column_name)
+        create_date_trunc_function unless date_trunc_function_exists?
+        "ACTIVE_REPORTING_DATE_TRUNC('#{datetime_precision_value}', #{quoted_table_name}.#{column_name})"
+      end
+
+      def self.date_trunc_function_exists?
+        ActiveRecord::Base.connection.execute(
+          <<-SQL
+            SELECT ROUTINE_NAME
+            FROM INFORMATION_SCHEMA.ROUTINES
+            WHERE ROUTINE_TYPE="FUNCTION"
+            AND UCASE(ROUTINE_NAME) = 'ACTIVE_REPORTING_DATE_TRUNC';
+          SQL
+        ).first.present?
+      end
+
+      def self.create_date_trunc_function
+        ActiveRecord::Base.connection.execute(
+          <<-SQL
+            CREATE FUNCTION ACTIVE_REPORTING_DATE_TRUNC(field ENUM('microsecond', 'millisecond', 'second', 'minute', 'hour', 'day', 'week', 'month', 'quarter', 'year', 'decade', 'century', 'millennium'), source datetime(6))
+            RETURNS datetime(6)
+            DETERMINISTIC
+            BEGIN
+              IF field IN ('millisecond') THEN SET source = source - INTERVAL MICROSECOND(source) % 1000 MICROSECOND; END IF;
+              IF field NOT IN ('microsecond', 'millisecond') THEN SET source = source - INTERVAL MICROSECOND(source) MICROSECOND; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second') THEN SET source = source - INTERVAL SECOND(source) SECOND; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second', 'minute') THEN SET source = source - INTERVAL MINUTE(source) MINUTE; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second', 'minute', 'hour') THEN SET source = source - INTERVAL HOUR(source) HOUR; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second', 'minute', 'hour', 'day') THEN SET source = source - INTERVAL DAYOFWEEK(source) - 1 DAY; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second', 'minute', 'hour', 'day', 'week') THEN SET source = source - INTERVAL DAY(source) - 1 DAY; END IF;
+              IF field IN ('quarter') THEN SET source = source - INTERVAL MONTH(source) % 3 - 1 MONTH; END IF;
+              IF field NOT IN ('microsecond', 'millisecond', 'second', 'minute', 'hour', 'week', 'day', 'month', 'quarter') THEN SET source = source - INTERVAL MONTH(source) - 1 MONTH; END IF;
+
+              -- Year ranges go from 1 - 10, e.g. 1961-1970, not 1960-1969. The third millenium started 2001, not 2000. If you want it the other way, remove the "- 1" from each of the following.
+              IF field IN ('decade') THEN SET source = source - INTERVAL YEAR(source) % 10 - 1 YEAR; END IF;
+              IF field IN ('century') THEN SET source = source - INTERVAL YEAR(source) % 100  - 1 YEAR; END IF;
+              IF field IN ('millennium') THEN SET source = source - INTERVAL YEAR(source) % 1000 - 1 YEAR; END IF;
+              RETURN source;
+            END
+          SQL
+        )
+      end
+    end
+  end
+end

--- a/lib/active_reporting/function_adapters/mysql.rb
+++ b/lib/active_reporting/function_adapters/mysql.rb
@@ -49,7 +49,7 @@ module ActiveReporting
             RETURNS datetime(6)
             DETERMINISTIC
             BEGIN
-              -- Short-circut in the week, month, or year, since those computations are straightforward
+              -- Short-circuit in the week, month, or year, since those computations are straightforward
               IF field IN ('week') THEN RETURN STR_TO_DATE(CONCAT(YEARWEEK(source, 2), ' Sunday'), '%X%V %W'); END IF;
               IF field IN ('month') THEN RETURN DATE_FORMAT(source, '%Y-%m-01'); END IF;
               IF field IN ('year') THEN RETURN DATE_FORMAT(source, '%Y-01-01'); END IF;

--- a/lib/active_reporting/function_adapters/mysql.rb
+++ b/lib/active_reporting/function_adapters/mysql.rb
@@ -49,6 +49,12 @@ module ActiveReporting
             RETURNS datetime(6)
             DETERMINISTIC
             BEGIN
+              -- Short-circut in the week, month, or year, since those computations are straightforward
+              IF field IN ('week') THEN RETURN STR_TO_DATE(CONCAT(YEARWEEK(source, 2), ' Sunday'), '%X%V %W'); END IF;
+              IF field IN ('month') THEN RETURN DATE_FORMAT(source, '%Y-%m-01'); END IF;
+              IF field IN ('year') THEN RETURN DATE_FORMAT(source, '%Y-01-01'); END IF;
+
+              -- Otherwise, we need to build the appropriate result
               IF field IN ('millisecond') THEN SET source = source - INTERVAL MICROSECOND(source) % 1000 MICROSECOND; END IF;
               IF field NOT IN ('microsecond', 'millisecond') THEN SET source = source - INTERVAL MICROSECOND(source) MICROSECOND; END IF;
               IF field NOT IN ('microsecond', 'millisecond', 'second') THEN SET source = source - INTERVAL SECOND(source) SECOND; END IF;

--- a/lib/active_reporting/function_adapters/postgresql.rb
+++ b/lib/active_reporting/function_adapters/postgresql.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ActiveReporting
+  module FunctionAdapters
+    module Postgresql
+      # The list of available datetime values.
+      #
+      # @return [Array<Symbol>]
+      #
+      def self.datetime_precision_values
+        %i[microseconds milliseconds second minute hour day week month quarter year decade
+           century millennium].freeze
+      end
+
+      # Whether the arg value is supported as a viable datetime
+      # value for performing datetime functions.
+      #
+      def self.valid_datetime_precision_value?(value)
+        datetime_precision_values.include?(value)
+      end
+
+      # Generate a date truncation statement in PostgreSQL
+      # See https://www.postgresql.org/docs/10/static/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC
+      #
+      # @param [String, Symbol] datetime_precision_value
+      # @param [String] quoted_table_name
+      # @param [String] column_name
+      #
+      def self.date_truncate(datetime_precision_value, quoted_table_name, column_name)
+        "DATE_TRUNC('#{datetime_precision_value}', #{quoted_table_name}.#{column_name})"
+      end
+    end
+  end
+end

--- a/test/active_reporting/report_test.rb
+++ b/test/active_reporting/report_test.rb
@@ -6,6 +6,24 @@ class ActiveReporting::ReportTest < Minitest::Test
     @report = ActiveReporting::Report.new(@metric)
   end
 
+  def users_created_in_different_testable_time_periods
+    t = User.last.created_at # Existing seed users a good reference point
+    users = [User.create(username: 'user_minute', created_at: t - 1.minute)]
+    users << User.create(username: 'user_hour', created_at: t - 1.hour)
+    users << User.create(username: 'user_day', created_at: t - 1.day)
+    users << User.create(username: 'user_week', created_at: t - 1.week)
+    users << User.create(username: 'user_month', created_at: t - 1.month)
+    users << User.create(username: 'user_quarter', created_at: t - 3.months)
+    users << User.create(username: 'user_year', created_at: t - 1.year)
+    users << User.create(username: 'user_decade', created_at: t - 10.years)
+    users << User.create(username: 'user_century', created_at: t - 100.years)
+    users << User.create(username: 'user_millennium', created_at: t - 1000.years)
+  end
+
+  def datetime_testable_periods
+    %i[minute hour day week month quarter year decade century millennium]
+  end
+
   def test_run_returns_an_array
     assert @report.run.is_a?(Array), 'result is not an array'
   end
@@ -33,28 +51,24 @@ class ActiveReporting::ReportTest < Minitest::Test
   end
 
   def test_report_runs_with_a_date_grouping
-    db = ENV['DB']
-    if db == 'pg' || db == 'mysql'
-      function_adapter = if db == 'pg'
-                           ActiveReporting::FunctionAdapters::Postgresql
-                         else
-                           ActiveReporting::FunctionAdapters::Mysql
-                         end
-      function_adapter.datetime_precision_values.each do |precision_value|
-        metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: precision_value}])
+    if %w[pg mysql].include?(ENV['DB'])
+      users = users_created_in_different_testable_time_periods
+      # Based on the 5 users created in seed.rb and the 10 just created,
+      # we can expect 11 different data segments when dimensioning by minute.
+      expected_result_size_when_dimensioning_by_minute = 11
+      datetime_testable_periods.each_with_index do |period, i|
+        metric = ActiveReporting::Metric.new(
+          :a_metric,
+          fact_model: UserFactModel,
+          dimensions: [{created_at: period}]
+        )
         report = ActiveReporting::Report.new(metric)
         data = report.run
-        assert data.all? { |r| r.key?("created_at_#{precision_value}") }
-        expected_size = case precision_value
-                        when :quarter
-                          2
-                        when :year, :decade, :centry, :millenium
-                          1
-                        else
-                          5
-                        end
-        data.size == expected_size
+        assert data.all? { |r| r.key?("created_at_#{period}") }
+        # As we expand the time period dimension, we can expect one less result
+        assert data.size == expected_result_size_when_dimensioning_by_minute - i
       end
+      users.each(&:destroy!) # Cleanup
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do
         metric = ActiveReporting::Metric.new(:a_metric, fact_model: UserFactModel, dimensions: [{created_at: :month}])

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -87,7 +87,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
   def test_label_can_be_passed_in_if_dimension_is_datetime
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
-    if ENV['DB'] == 'pg'
+    if ENV['DB'] == 'pg' || ENV['DB'] == 'mysql'
       ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do

--- a/test/active_reporting/reporting_dimension_test.rb
+++ b/test/active_reporting/reporting_dimension_test.rb
@@ -87,7 +87,7 @@ class ActiveReporting::ReportingDimensionTest < ActiveSupport::TestCase
   def test_label_can_be_passed_in_if_dimension_is_datetime
     refute @user_dimension.hierarchical?
     assert @user_dimension.type == ActiveReporting::Dimension::TYPES[:degenerate]
-    if ENV['DB'] == 'pg' || ENV['DB'] == 'mysql'
+    if %w[pg mysql].include?(ENV['DB'])
       ActiveReporting::ReportingDimension.new(@user_dimension, label: :year)
     else
       assert_raises ActiveReporting::InvalidDimensionLabel do

--- a/test/seed.rb
+++ b/test/seed.rb
@@ -3,13 +3,9 @@
 end
 
 (1..5).each do |i|
-  user = User.create!(
-    created_at: Time.now - i.months,
-    username: "user_#{i}"
-  )
+  user = User.create!(username: "user_#{i}")
 
   Profile.create!(
-    created_at: Time.now - i.months,
     user: user,
     favorite_pokemon: 'Pikachu'
   )

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,8 +25,8 @@ when 'mysql'
   ActiveRecord::Base.establish_connection(
     adapter:  'mysql2',
     database: 'active_reporting_test',
-    username: 'Nick',
-    password: 'password',
+    # username: 'mysql', # Uncomment if you need this
+    # password: 'mysql', # Uncomment if you need this
     encoding: 'utf8'
   )
 when 'sqlite'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,8 @@ when 'mysql'
   ActiveRecord::Base.establish_connection(
     adapter:  'mysql2',
     database: 'active_reporting_test',
+    username: 'Nick',
+    password: 'password',
     encoding: 'utf8'
   )
 when 'sqlite'


### PR DESCRIPTION
Follows t27duck/active_reporting#10, which provided implicit
datetime hierarchies for Postgres.

One improvement that might be made is with respect to the MySQL
implementation of the Postgres date_trunc function. Currently,
the code creates a function in the database to undertake the
date_trunc functionality. However, it seems to me that a better
approach would be to have an anonymous function perform this
action, and avoid polluting a user's database.