### PR TITLE
Configure MySQL date_trunc function to start week on Monday

### DIFF
--- a/lib/active_reporting/function_adapters/mysql.rb
+++ b/lib/active_reporting/function_adapters/mysql.rb
@@ -28,7 +28,11 @@ module ActiveReporting
       #
       def self.date_truncate(datetime_precision_value, quoted_table_name, column_name)
         create_date_trunc_function unless date_trunc_function_exists?
-        "ACTIVE_REPORTING_DATE_TRUNC('#{datetime_precision_value}', #{quoted_table_name}.#{column_name})"
+        _active_reporting_date_trunc(datetime_precision_value, "#{quoted_table_name}.#{column_name}")
+      end
+
+      def self._active_reporting_date_trunc(datetime_precision_value, value)
+        "ACTIVE_REPORTING_DATE_TRUNC('#{datetime_precision_value}', #{value})"
       end
 
       def self.date_trunc_function_exists?
@@ -50,7 +54,7 @@ module ActiveReporting
             DETERMINISTIC
             BEGIN
               -- Short-circuit in the week, month, or year, since those computations are straightforward
-              IF field IN ('week') THEN RETURN STR_TO_DATE(CONCAT(YEARWEEK(source, 2), ' Sunday'), '%X%V %W'); END IF;
+              IF field IN ('week') THEN RETURN STR_TO_DATE(CONCAT(YEARWEEK(source, 2), ' Monday'), '%X%V %W'); END IF;
               IF field IN ('month') THEN RETURN DATE_FORMAT(source, '%Y-%m-01'); END IF;
               IF field IN ('year') THEN RETURN DATE_FORMAT(source, '%Y-01-01'); END IF;
 

--- a/test/active_reporting/function_adapaters/mysql_test.rb
+++ b/test/active_reporting/function_adapaters/mysql_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ActiveReporting::FunctionAdapters::MysqlTest < Minitest::Test
+  def adapter
+    ActiveReporting::FunctionAdapters::Mysql
+  end
+  # Postgres and Ruby follow ISO standards for Monday being the start of
+  # the week -- Postgres' `date_trunc` function follows that convention.
+  # Here we test that our MySQL port does the same.
+  #
+  def test_date_trunc_returns_monday_for_week_start
+    return unless 'mysql' == ENV['DB']
+    if adapter.date_trunc_function_exists?
+      ActiveRecord::Base.connection.execute(
+        'DROP FUNCTION IF EXISTS ACTIVE_REPORTING_DATE_TRUNC'
+      )
+    end
+    adapter.create_date_trunc_function
+    stmt = ActiveReporting::FunctionAdapters::Mysql._active_reporting_date_trunc(
+      'week', "TIMESTAMP '#{Date.parse('2018-09-29').beginning_of_day.strftime('%F %T')}'"
+    )
+    result = ActiveRecord::Base.connection.exec_query("SELECT #{stmt} AS foo")
+    assert result.first['foo'].to_s == '2018-09-24 00:00:00 UTC' # A Monday
+  end
+end


### PR DESCRIPTION
Conforms the MySQL "week" date_trunc-equivalent function to use
Monday as the starting day of the week, as Ruby and Postgres do.