### PR TITLE
Bugfix - add DISTINCT to count queries to prevent double counting of matters

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -78,7 +78,15 @@ module ActiveReporting
     def select_aggregate
       case @metric.aggregate
       when :count
-        "COUNT(#{@metric.aggregate_expression || '*'})"
+        distinct = "DISTINCT `#{@metric.model.name_without_component.downcase.pluralize}`.`id`"
+
+        count_params = if @metric.aggregate_expression
+                         "#{distinct}, #{@metric.aggregate_expression}"
+                       else
+                         distinct
+                       end
+
+        "COUNT(#{count_params})"
       else
         "#{@metric.aggregate.to_s.upcase}(#{@metric.aggregate_expression || fact_model.measure})"
       end

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.4.8'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
This change resolves a bug where some objects were being double counted when using the `ActiveReporting::Report` class.

The aggregate used in the `select` query for reports includes inner joins between the table representing the `FactModel` under consideration, and the various relevant tables specified by the `dimension_filter` parameters. 

For example, consider a model called Jobs, where each job can have many users assigned to it. A report on the Jobs table with a filter for assigned users would run a query similar to the following:
```
SELECT COUNT(*) AS job_count, FROM jobs INNER JOIN assignments ON assignments.assignable_id = jobs.id
```
If one or more jobs have multiple users assigned, there will be multiple matching rows in the `assignments` table and therefore the total count of jobs will be inaccurate. 

This can be resolved by adding a `DISTINCT <model.id>` declaration to the query, where the model is the model the report is being generated for. In the example above, the query would now be:
```
SELECT COUNT(DISTINCT jobs.id) AS job_count, FROM jobs INNER JOIN assignments ON assignments.assignable_id = jobs.id
```

Adding `DISTINCT` ensures that only unique rows are included in the final count.

Joint work with @etsenake. 