### PR TITLE
Handle has_many relationships for SUM operations

### DIFF
--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -75,6 +75,7 @@ module ActiveReporting
         # attempting the sum. Therefore we build up the query piece
         # by piece rather than using the basic statement.
 
+        outer_select = outer_select_statement.join(',')
 
         # In some situations the column we're summing over is not included as a part of the aggregation
         # in the inner query. In such cases we must explicitly select the desired column in the inner
@@ -85,9 +86,11 @@ module ActiveReporting
           selection_metric = ''
         end
 
-        # Construct each piece we need for the final query
-        outer_select = outer_select_statement.join(',')
-        inner_columns = inner_select_statement.empty? ? "#{selection_metric}" : ",#{inner_select_statement.join(',')}"
+        inner_columns = ",#{inner_select_statement.join(',')}"
+        if selection_metric && !inner_columns.include?(selection_metric)
+          inner_columns = "#{selection_metric}#{inner_columns}"
+        end
+
         inner_select = "SELECT #{distinct}, #{fact_model.measure.to_s} #{inner_columns}"
         inner_from = statement.to_sql.split('FROM').last
 

--- a/lib/active_reporting/report.rb
+++ b/lib/active_reporting/report.rb
@@ -70,7 +70,7 @@ module ActiveReporting
         statement = process_lambda_dimension_filter(statement)
         statement = process_ransack_dimension_filter(statement)
 
-        # The original gem did not handle has_many relatinoships. In order to support
+        # The original gem did not handle has_many relationships. In order to support
         # has_many, we need to first do an inner query to select out distinct rows _before_
         # attempting the sum. Therefore we build up the query piece
         # by piece rather than using the basic statement.

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -35,9 +35,32 @@ module ActiveReporting
     # @return [Array]
     def select_statement(with_identifier: true)
       return [degenerate_select_fragment] if type == Dimension::TYPES[:degenerate]
-
       ss = ["#{label_fragment} AS #{name}"]
       ss << "#{identifier_fragment} AS #{name}_identifier" if with_identifier
+      ss
+    end
+
+    # Fragments of a select statement for queries that use the dimension
+    # but where we always want to rename, even if the fragment is degenerate
+    # (aka if it is not a foreign key)
+    #
+    # @return [Array]
+    def select_statement_always_rename(with_identifier: true)
+      return [name] if type == Dimension::TYPES[:degenerate]
+      ss = ["#{label_fragment} AS #{name}"]
+      ss << "#{identifier_fragment} AS #{name}_identifier" if with_identifier
+      ss
+    end
+
+    # Fragment of a select statement for queries that use a dimension
+    # but without renaming returned columnns with 'AS'
+    #
+    # @return [ARRAY]
+    def select_statement_no_rename(with_identifier: true) #TODO RENAME THIS BC IT SUCKS
+      return [name] if type == Dimension::TYPES[:degenerate]
+
+      ss = ["#{name}"]
+      ss << "#{name}_identifier" if with_identifier
       ss
     end
 

--- a/lib/active_reporting/reporting_dimension.rb
+++ b/lib/active_reporting/reporting_dimension.rb
@@ -56,7 +56,7 @@ module ActiveReporting
     # but without renaming returned columnns with 'AS'
     #
     # @return [ARRAY]
-    def select_statement_no_rename(with_identifier: true) #TODO RENAME THIS BC IT SUCKS
+    def select_statement_no_rename(with_identifier: true)
       return [name] if type == Dimension::TYPES[:degenerate]
 
       ss = ["#{name}"]

--- a/lib/active_reporting/version.rb
+++ b/lib/active_reporting/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveReporting
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
This PR changes how the sql statement is constructed in the case of SUM operations to correctly handle has_many relationships and avoid double counting. This is accomplished by constructing an inner query which selects distinct rows, and then performing the sum on the result of that inner query.

For example, an original query of the following form:
```
SELECT SUM(CASE WHEN category = 0 THEN value END) AS grand_total FROM `jobs` INNER JOIN `job_statuses` ON `job_statuses`.`id` = `jobs`.`job_status_id` AND `job_statuses`.`account_id` = 1 INNER JOIN `assignments` ON `assignments`.`assignable_id` = `jobs.`id` AND `assignments`.`account_id` = 1 WHERE `matters`.`account_id` = 1 ;
```

would now be represented as:
```
SELECT SUM(CASE WHEN category = 0 THEN value END) AS grand_total FROM(SELECT DISTINCT `jobs`.`id`, value, category FROM `jobs` INNER JOIN `job_statuses` ON `job_statuses`.`id` = `jobs`.`job_status_id` AND `job_statuses`.`account_id` = 1 INNER JOIN `assignments` ON `assignments`.`assignable_id` = `jobs.`id` AND `assignments`.`account_id` = 1 WHERE `matters`.`account_id` = 1 )AS T ;
```
ensuring that each target value is only added to the total sum once.